### PR TITLE
DRAUP 🤝 delegate.cash

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "lib/draup-utils"]
 	path = lib/draup-utils
 	url = https://github.com/draup-fashion/draup-utils
+[submodule "lib/delegation-registry"]
+	path = lib/delegation-registry
+	url = https://github.com/delegatecash/delegation-registry

--- a/remappings.txt
+++ b/remappings.txt
@@ -4,3 +4,4 @@ solmate/=lib/solmate/src/
 openzeppelin-contracts/=lib/openzeppelin-contracts
 operator-filter-registry/=lib/operator-filter-registry
 draup-utils/=lib/draup-utils
+delegation-registry/=lib/delegation-registry

--- a/test/MetadataTest.t.sol
+++ b/test/MetadataTest.t.sol
@@ -27,7 +27,7 @@ contract DraupMembershipERC721MetadataTest is Test {
         merkleProof[1] = hex'b83b0d782919b4ecc6cb4f744339823754ed3d3e980cdf8204194bfa6bab1de8';
         merkleProof[2] = hex'e1196e36db67e723e3b325b53c9f124eb38460ed3c1e0b6a7b501cf9478f6ab0';
         vm.prank(minter);
-        draupMembershipERC721.mint(merkleProof);
+        draupMembershipERC721.mint(merkleProof, address(0));
     }
 
     function testNoMetadataForUnmintedTokens() public {

--- a/test/MintTest.t.sol
+++ b/test/MintTest.t.sol
@@ -30,12 +30,19 @@ contract DraupMembershipERC721MintTest is Test {
         merkleProof[1] = bytes32('med3af');
         vm.startPrank(minter);
         vm.expectRevert(abi.encodeWithSelector(DraupMembershipERC721.InvalidProof.selector));
-        draupMembershipERC721.mint(merkleProof);
+        draupMembershipERC721.mint(merkleProof, address(0));
+    }
+
+    function testMintingAllowedBlocksInvalidMerkleProof() public {
+        merkleProof[1] = bytes32('med3af');
+        vm.startPrank(minter);
+        vm.expectRevert(abi.encodeWithSelector(DraupMembershipERC721.InvalidProof.selector));
+        draupMembershipERC721.mintingAllowed(merkleProof, address(0));
     }
 
     function testMintAllowsValidMerkleProof() public {
         vm.startPrank(minter);
-        draupMembershipERC721.mint(merkleProof);
+        draupMembershipERC721.mint(merkleProof, address(0));
         uint256 newBalance = draupMembershipERC721.balanceOf(minter);
         assertEq(newBalance, 1);
     }
@@ -44,21 +51,21 @@ contract DraupMembershipERC721MintTest is Test {
         vm.expectEmit(true, true, true, false);
         emit Transfer(address(0x0), minter, 0);
         vm.startPrank(minter);
-        draupMembershipERC721.mint(merkleProof);
+        draupMembershipERC721.mint(merkleProof, address(0));
     }
 
     function testMintPreventsReuseOfAllowListSpot() public {
         vm.startPrank(minter);
-        draupMembershipERC721.mint(merkleProof);
+        draupMembershipERC721.mint(merkleProof, address(0));
         assertEq(draupMembershipERC721.balanceOf(minter), 1);
         vm.expectRevert(abi.encodeWithSelector(DraupMembershipERC721.AlreadyClaimed.selector));
-        draupMembershipERC721.mint(merkleProof);
+        draupMembershipERC721.mint(merkleProof, address(0));
         assertEq(draupMembershipERC721.balanceOf(minter), 1);
     }
 
     function testMintEnforcesMaxSupply() public {
         vm.prank(minter);
-        draupMembershipERC721.mint(merkleProof);
+        draupMembershipERC721.mint(merkleProof, address(0));
         assertEq(draupMembershipERC721.balanceOf(minter), 1);
 
         bytes32[] memory merkleProof2 = new bytes32[](3);
@@ -68,7 +75,7 @@ contract DraupMembershipERC721MintTest is Test {
         address minter2 = 0x502367Ea6eA7ED256A55Ff70340EB81bF0e11bC2;
         assertEq(draupMembershipERC721.balanceOf(minter2), 0);
         vm.prank(minter2);
-        draupMembershipERC721.mint(merkleProof2);
+        draupMembershipERC721.mint(merkleProof2, address(0));
         assertEq(draupMembershipERC721.balanceOf(minter2), 1);
 
         bytes32[] memory merkleProof3 = new bytes32[](4);
@@ -79,7 +86,7 @@ contract DraupMembershipERC721MintTest is Test {
         address minter3 = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
         assertEq(draupMembershipERC721.balanceOf(minter3), 0);
         vm.prank(minter3);
-        draupMembershipERC721.mint(merkleProof3);
+        draupMembershipERC721.mint(merkleProof3, address(0));
         assertEq(draupMembershipERC721.balanceOf(minter3), 1);
 
         bytes32[] memory merkleProof4 = new bytes32[](3);
@@ -90,7 +97,7 @@ contract DraupMembershipERC721MintTest is Test {
         assertEq(draupMembershipERC721.balanceOf(minter4), 0);
         vm.prank(minter4);
         vm.expectRevert(abi.encodeWithSelector(DraupMembershipERC721.MaxSupplyReached.selector));
-        draupMembershipERC721.mint(merkleProof4);
+        draupMembershipERC721.mint(merkleProof4, address(0));
         assertEq(draupMembershipERC721.balanceOf(minter4), 0);
     }
 }

--- a/test/MintTest.t.sol
+++ b/test/MintTest.t.sol
@@ -47,6 +47,12 @@ contract DraupMembershipERC721MintTest is Test {
         assertEq(newBalance, 1);
     }
 
+    function testMintingAllowedAllowsValidMerkleProof() public {
+        vm.startPrank(minter);
+        address allowedAddress = draupMembershipERC721.mintingAllowed(merkleProof, address(0));
+        assertEq(allowedAddress, minter);
+    }
+
     function testMintEmitsTransferEvent() public {
         vm.expectEmit(true, true, true, false);
         emit Transfer(address(0x0), minter, 0);
@@ -61,6 +67,16 @@ contract DraupMembershipERC721MintTest is Test {
         vm.expectRevert(abi.encodeWithSelector(DraupMembershipERC721.AlreadyClaimed.selector));
         draupMembershipERC721.mint(merkleProof, address(0));
         assertEq(draupMembershipERC721.balanceOf(minter), 1);
+    }
+
+    function testMintingAllowedPreventsReuseOfAllowListSpot() public {
+        vm.startPrank(minter);
+        address mintCheck = draupMembershipERC721.mintingAllowed(merkleProof, address(0));
+        assertEq(mintCheck, minter);
+        draupMembershipERC721.mint(merkleProof, address(0));
+        assertEq(draupMembershipERC721.balanceOf(minter), 1);
+        vm.expectRevert(abi.encodeWithSelector(DraupMembershipERC721.AlreadyClaimed.selector));
+        draupMembershipERC721.mintingAllowed(merkleProof, address(0));
     }
 
     function testMintEnforcesMaxSupply() public {

--- a/test/RoyaltyTest.t.sol
+++ b/test/RoyaltyTest.t.sol
@@ -24,7 +24,7 @@ contract DraupMembershipERC721AllowListTest is Test {
         merkleProof[1] = hex'b83b0d782919b4ecc6cb4f744339823754ed3d3e980cdf8204194bfa6bab1de8';
         merkleProof[2] = hex'e1196e36db67e723e3b325b53c9f124eb38460ed3c1e0b6a7b501cf9478f6ab0';
         vm.prank(minter);
-        draupMembershipERC721.mint(merkleProof);
+        draupMembershipERC721.mint(merkleProof, address(0));
     }
 
     function testRoyaltyOnLargeAmounts() public {

--- a/test/TransferTest.t.sol
+++ b/test/TransferTest.t.sol
@@ -24,7 +24,7 @@ contract DraupMembershipERC721AllowListTest is Test {
         merkleProof[1] = hex'b83b0d782919b4ecc6cb4f744339823754ed3d3e980cdf8204194bfa6bab1de8';
         merkleProof[2] = hex'e1196e36db67e723e3b325b53c9f124eb38460ed3c1e0b6a7b501cf9478f6ab0';
         vm.prank(minter);
-        draupMembershipERC721.mint(merkleProof);
+        draupMembershipERC721.mint(merkleProof, address(0));
     }
 
     function testOnlyAdminCanEnableTransfers() public {


### PR DESCRIPTION
Integrating with the utility contract delegate.cash which allows cold wallets to delegate allow list access to hot wallets. The check happens on minting and the hot wallet user must pass in the address of the cold wallet they are acting on. The mint function then calls out to the delegate.cash contract at 0x00000000000076A84feF008CDAbe6409d2FE638B (on all chains) and checks to see if the passed in cold wallet has delegate to the hot wallet. If so the mint proceeds as if the cold wallet did it. If the check fails the mint reverts. 

This also adds a new public method `mintingAllowed` which contains just the validations for minting. The idea is to make them more usable from the front end code. 